### PR TITLE
Add from_tree_sequences builder

### DIFF
--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -264,3 +264,215 @@ class TestFromSlim:
         ts = tables.tree_sequence()
         with pytest.raises(ValueError, match="this_chromosome"):
             tmc.from_slim([ts])
+
+
+class TestFromTreeSequences:
+    def test_basic(self):
+        """Test basic construction with default shared_nodes=None."""
+        ts1 = make_ts(seq_len=1000, num_samples=4, mark_shared=False)
+        ts2 = make_ts(seq_len=2000, num_samples=4, mark_shared=False)
+        ta = tmc.from_tree_sequences(
+            [ts1, ts2],
+            ids=[20, 21],
+            symbols=["20", "21"],
+            types=["A", "A"],
+        )
+        assert ta.num_contigs == 2
+        assert ta.contig("20").sequence_length == 1000
+        assert ta.contig("21").sequence_length == 2000
+
+    def test_default_shared_nodes_none(self):
+        """Test that the default shared_nodes=None marks no nodes as IS_SHARED."""
+        ts1 = make_ts(seq_len=1000, num_samples=4, mark_shared=False)
+        ta = tmc.from_tree_sequences(
+            [ts1],
+            ids=[1],
+            symbols=["chr1"],
+            types=["A"],
+        )
+        ts = ta.contig("chr1")
+        # Verify that no nodes have IS_SHARED marked
+        for nid in range(ts.num_nodes):
+            assert not (ts.tables.nodes[nid].flags & tmc.NODE_IS_SHARED)
+
+    def test_contig_keys_created(self):
+        """Test that ContigKey objects are created with correct values."""
+        ts1 = make_ts(seq_len=1000, num_samples=4, mark_shared=False)
+        ts2 = make_ts(seq_len=2000, num_samples=4, mark_shared=False)
+        ta = tmc.from_tree_sequences(
+            [ts1, ts2],
+            ids=[20, 21],
+            symbols=["chr20", "chr21"],
+            types=["A", "A"],
+            indexes=[10, 11],
+            shared_nodes="samples",
+        )
+        key1 = tmc.ContigKey(index=10, id=20, symbol="chr20", type="A")
+        key2 = tmc.ContigKey(index=11, id=21, symbol="chr21", type="A")
+        assert key1 in ta
+        assert key2 in ta
+
+    def test_sample_nodes_marked_shared(self):
+        """Test that sample nodes are marked as IS_SHARED when shared_nodes='samples'."""
+        ts1 = make_ts(seq_len=1000, num_samples=4, mark_shared=False)
+        ta = tmc.from_tree_sequences(
+            [ts1],
+            ids=[1],
+            symbols=["chr1"],
+            types=["A"],
+            shared_nodes="samples",
+        )
+        ts = ta.contig("chr1")
+        sample_ids = ts.samples()
+        for sample_id in sample_ids:
+            assert ts.tables.nodes[sample_id].flags & tmc.NODE_IS_SHARED
+
+    def test_non_sample_nodes_not_marked_shared(self):
+        """Test that non-sample nodes are not marked as IS_SHARED when shared_nodes='samples'."""
+        ts1 = make_ts(seq_len=1000, num_samples=4, mark_shared=False)
+        ta = tmc.from_tree_sequences(
+            [ts1],
+            ids=[1],
+            symbols=["chr1"],
+            types=["A"],
+            shared_nodes="samples",
+        )
+        ts = ta.contig("chr1")
+        sample_ids = set(ts.samples())
+        for nid in range(ts.num_nodes):
+            if nid not in sample_ids:
+                assert not (ts.tables.nodes[nid].flags & tmc.NODE_IS_SHARED)
+
+    def test_list_of_node_ids_marked_shared(self):
+        """Test marking a specific list of node IDs as IS_SHARED."""
+        ts1 = make_ts(seq_len=1000, num_samples=4, mark_shared=False)
+        # ts1 has 5 nodes: 4 samples and 1 ancestor
+        shared_node_ids = [0, 1, 4]  # Mark first two samples and the ancestor
+        ta = tmc.from_tree_sequences(
+            [ts1],
+            ids=[1],
+            symbols=["chr1"],
+            types=["A"],
+            shared_nodes=shared_node_ids,
+        )
+        ts = ta.contig("chr1")
+        # Check that specified nodes have IS_SHARED set
+        for nid in shared_node_ids:
+            assert ts.tables.nodes[nid].flags & tmc.NODE_IS_SHARED, f"Node {nid} not marked"
+        # Check that unspecified nodes do not have IS_SHARED
+        for nid in [2, 3]:
+            assert not (ts.tables.nodes[nid].flags & tmc.NODE_IS_SHARED), f"Node {nid} marked"
+
+    def test_default_indexes(self):
+        """Test that indexes default to [0, 1, 2, ...] when not provided."""
+        ts1 = make_ts(seq_len=1000, num_samples=4, mark_shared=False)
+        ts2 = make_ts(seq_len=2000, num_samples=4, mark_shared=False)
+        ta = tmc.from_tree_sequences(
+            [ts1, ts2],
+            ids=[20, 21],
+            symbols=["20", "21"],
+            types=["A", "A"],
+        )
+        # Check that contigs are accessible and in order
+        contigs = ta.contigs
+        assert contigs[0].index == 0
+        assert contigs[1].index == 1
+
+    def test_custom_indexes(self):
+        """Test that custom indexes are respected."""
+        ts1 = make_ts(seq_len=1000, num_samples=4, mark_shared=False)
+        ts2 = make_ts(seq_len=2000, num_samples=4, mark_shared=False)
+        ta = tmc.from_tree_sequences(
+            [ts1, ts2],
+            ids=[20, 21],
+            symbols=["20", "21"],
+            types=["A", "A"],
+            indexes=[100, 101],
+        )
+        contigs = ta.contigs
+        assert contigs[0].index == 100
+        assert contigs[1].index == 101
+
+    def test_empty_list_raises(self):
+        """Test that empty tree_sequences list raises ValueError."""
+        with pytest.raises(ValueError, match="empty"):
+            tmc.from_tree_sequences(
+                [],
+                ids=[],
+                symbols=[],
+                types=[],
+            )
+
+    def test_mismatched_ids_raises(self):
+        """Test that mismatched ids length raises ValueError."""
+        ts1 = make_ts(seq_len=1000, num_samples=4, mark_shared=False)
+        ts2 = make_ts(seq_len=2000, num_samples=4, mark_shared=False)
+        with pytest.raises(ValueError, match="ids.*same length"):
+            tmc.from_tree_sequences(
+                [ts1, ts2],
+                ids=[20],  # Only one id instead of two
+                symbols=["20", "21"],
+                types=["A", "A"],
+            )
+
+    def test_mismatched_symbols_raises(self):
+        """Test that mismatched symbols length raises ValueError."""
+        ts1 = make_ts(seq_len=1000, num_samples=4, mark_shared=False)
+        ts2 = make_ts(seq_len=2000, num_samples=4, mark_shared=False)
+        with pytest.raises(ValueError, match="symbols.*same length"):
+            tmc.from_tree_sequences(
+                [ts1, ts2],
+                ids=[20, 21],
+                symbols=["20"],  # Only one symbol instead of two
+                types=["A", "A"],
+            )
+
+    def test_mismatched_types_raises(self):
+        """Test that mismatched types length raises ValueError."""
+        ts1 = make_ts(seq_len=1000, num_samples=4, mark_shared=False)
+        ts2 = make_ts(seq_len=2000, num_samples=4, mark_shared=False)
+        with pytest.raises(ValueError, match="types.*same length"):
+            tmc.from_tree_sequences(
+                [ts1, ts2],
+                ids=[20, 21],
+                symbols=["20", "21"],
+                types=["A"],  # Only one type instead of two
+            )
+
+    def test_mismatched_indexes_raises(self):
+        """Test that mismatched indexes length raises ValueError."""
+        ts1 = make_ts(seq_len=1000, num_samples=4, mark_shared=False)
+        ts2 = make_ts(seq_len=2000, num_samples=4, mark_shared=False)
+        with pytest.raises(ValueError, match="indexes.*same length"):
+            tmc.from_tree_sequences(
+                [ts1, ts2],
+                ids=[20, 21],
+                symbols=["20", "21"],
+                types=["A", "A"],
+                indexes=[0],  # Only one index instead of two
+            )
+
+    def test_invalid_shared_nodes_string_raises(self):
+        """Test that invalid shared_nodes string raises ValueError."""
+        ts1 = make_ts(seq_len=1000, num_samples=4, mark_shared=False)
+        with pytest.raises(ValueError, match="'samples'"):
+            tmc.from_tree_sequences(
+                [ts1],
+                ids=[1],
+                symbols=["chr1"],
+                types=["A"],
+                shared_nodes="invalid",
+            )
+
+    def test_invalid_shared_nodes_type_raises(self):
+        """Test that non-list shared_nodes raises ValueError."""
+        ts1 = make_ts(seq_len=1000, num_samples=4, mark_shared=False)
+        with pytest.raises(ValueError, match="list of node IDs"):
+            tmc.from_tree_sequences(
+                [ts1],
+                ids=[1],
+                symbols=["chr1"],
+                types=["A"],
+                shared_nodes=123,  # Neither "samples" nor list-like
+            )
+

--- a/tskit_multichrom/__init__.py
+++ b/tskit_multichrom/__init__.py
@@ -13,6 +13,14 @@ Quick start::
     # Load from a directory or zip archive
     ta = tmc.load("genome_trees")
 
+    # Create from a list of tree sequences
+    ta = tmc.from_tree_sequences(
+        [ts1, ts2],
+        ids=[1, 2],
+        symbols=["chr1", "chr2"],
+        types=["A", "A"],
+    )
+
     # Access a contig by symbol
     chr1_ts = ta.contig("chr1")
 
@@ -33,7 +41,7 @@ from .core import (
     TreesAssemblage,
     make_contig_key,
 )
-from .convert import from_slim, from_ts, to_ts
+from .convert import from_slim, from_tree_sequences, from_ts, to_ts
 from .flags import ARCHIVE_EXTENSION, CONTIG_METADATA_KEY, NODE_IS_SHARED
 from .io import dump, load
 from ._version import tskit_multichrom_version as __version__
@@ -50,6 +58,7 @@ __all__ = [
     "to_ts",
     "from_ts",
     "from_slim",
+    "from_tree_sequences",
     # Flags
     "NODE_IS_SHARED",
     "CONTIG_METADATA_KEY",

--- a/tskit_multichrom/convert.py
+++ b/tskit_multichrom/convert.py
@@ -16,6 +16,7 @@ records per-contig ``sequence_length``, ``num_nodes``, and ``contig``.
 are implicitly shared) into a :class:`TreesAssemblage`.
 """
 
+import copy
 import warnings
 import json
 
@@ -23,7 +24,7 @@ import numpy as np
 import tskit
 
 from ._version import tskit_multichrom_version
-from .core import TreesAssemblage, make_contig_key
+from .core import ContigKey, TreesAssemblage, make_contig_key
 from .flags import CONTIG_METADATA_KEY, NODE_IS_SHARED
 
 # Top-level metadata key used in the single-TS representation
@@ -511,6 +512,176 @@ def from_slim(tree_sequences, *, slim_metadata_key="SLiM"):
         result[key] = tables.tree_sequence()
 
     return TreesAssemblage(result)
+
+
+def from_tree_sequences(
+    tree_sequences,
+    ids,
+    symbols,
+    types,
+    indexes=None,
+    shared_nodes=None,
+):
+    """
+    Create a :class:`TreesAssemblage` from a list of tree sequences without contig metadata.
+
+    This function combines multiple independent tree sequences into a TreesAssemblage,
+    automatically annotating them with contig metadata and optionally marking shared nodes.
+
+    Parameters
+    ----------
+    tree_sequences : list[tskit.TreeSequence]
+        Tree sequences to assemble, one per contig.
+    ids : list[int]
+        Contig IDs (one per tree sequence).
+    symbols : list[str]
+        Contig symbols, e.g., ``["20", "21"]`` or ``["chrX", "chrY"]``
+        (one per tree sequence).
+    types : list[str]
+        Contig types (one per tree sequence). Examples: ``"A"`` for autosome,
+        ``"X"``, ``"Y"``, or ``"MT"``.
+    indexes : list[int], optional
+        Contig indexes (ordering integers, one per tree sequence). If None,
+        defaults to ``[0, 1, 2, ...]``.
+    shared_nodes : str or list[int], optional
+        Which nodes to mark with :data:`~tskit_multichrom.flags.NODE_IS_SHARED`:
+
+        - ``None`` (default): Do not mark any nodes as IS_SHARED.
+        - ``"samples"``: Mark all sample nodes as IS_SHARED.
+        - list-like of int: Mark the specified node IDs as IS_SHARED across all contigs.
+
+    Returns
+    -------
+    TreesAssemblage
+        A new TreesAssemblage with contigs in index order.
+
+    Raises
+    ------
+    ValueError
+        If the lengths of ``ids``, ``symbols``, ``types``, or ``indexes`` do not match
+        the length of ``tree_sequences``, or if ``shared_nodes`` is neither None, the string
+        ``"samples"``, nor a list-like of integers.
+
+    Examples
+    --------
+    >>> ta = from_tree_sequences(
+    ...     [ts20, ts21],
+    ...     ids=[20, 21],
+    ...     symbols=["20", "21"],
+    ...     types=["A", "A"],
+    ... )
+
+    Mark all sample nodes as shared:
+
+    >>> ta = from_tree_sequences(
+    ...     [ts20, ts21],
+    ...     ids=[20, 21],
+    ...     symbols=["20", "21"],
+    ...     types=["A", "A"],
+    ...     shared_nodes="samples",
+    ... )
+    """
+    if not tree_sequences:
+        raise ValueError("tree_sequences list cannot be empty")
+
+    n = len(tree_sequences)
+    if len(ids) != n or len(symbols) != n or len(types) != n:
+        raise ValueError(
+            "ids, symbols, and types must have the same length as tree_sequences"
+        )
+
+    if indexes is None:
+        indexes = list(range(n))
+    elif len(indexes) != n:
+        raise ValueError(
+            "If provided, indexes must have the same length as tree_sequences"
+        )
+
+    # Validate and process shared_nodes parameter
+    # mark_strategy will be:
+    #   None = don't mark anything
+    #   "samples" = mark all sample nodes
+    #   set of ints = mark specific node IDs
+    if shared_nodes is None:
+        mark_strategy = None
+    elif isinstance(shared_nodes, str):
+        if shared_nodes != "samples":
+            raise ValueError(
+                f"shared_nodes string must be 'samples', got {shared_nodes!r}"
+            )
+        mark_strategy = "samples"
+    else:
+        # Assume list-like of node IDs
+        try:
+            mark_strategy = set(int(nid) for nid in shared_nodes)
+        except (TypeError, ValueError) as e:
+            raise ValueError(
+                "shared_nodes must be None, 'samples', or a list of node IDs"
+            ) from e
+
+    # Build TreesAssemblage dict
+    ta_dict = {}
+    for i, (ts, idx, contig_id, symbol, typ) in enumerate(
+        zip(tree_sequences, indexes, ids, symbols, types)
+    ):
+        # Copy and modify tables to mark shared nodes
+        tables = ts.dump_tables()
+        
+        # Modify flags by creating a new array with selective modifications
+        flags = tables.nodes.flags.copy()
+
+        if mark_strategy == "samples":
+            # Mark all sample nodes as IS_SHARED
+            sample_node_ids = ts.samples()
+            flags[sample_node_ids] = flags[sample_node_ids] | NODE_IS_SHARED
+        elif mark_strategy is not None:
+            # Mark specified node IDs as IS_SHARED (if they exist in this tree sequence)
+            node_ids_to_mark = np.array(
+                [nid for nid in mark_strategy if nid < ts.num_nodes],
+                dtype=int
+            )
+            if len(node_ids_to_mark) > 0:
+                flags[node_ids_to_mark] = flags[node_ids_to_mark] | NODE_IS_SHARED
+        # else: mark_strategy is None, don't mark anything
+        
+        # Update the tables with the complete modified flags array
+        tables.nodes.flags = flags
+
+        # Create ContigKey and extract contig metadata dict
+        key = ContigKey(index=idx, id=contig_id, symbol=symbol, type=typ)
+        contig_dict = key._asdict()
+        
+        # Get current metadata
+        meta = ts.metadata
+        if not isinstance(meta, dict):
+            meta = {}
+        else:
+            meta = dict(meta)  # Copy to avoid mutating original
+        
+        meta[CONTIG_METADATA_KEY] = contig_dict
+        
+        # Ensure top-level metadata schema is permissive JSON
+        existing_schema = ts.metadata_schema.schema
+        if not existing_schema or existing_schema.get("codec") != "json":
+            tables.metadata_schema = tskit.MetadataSchema.permissive_json()
+        else:
+            # Ensure the schema allows the contig key
+            schema_dict = copy.deepcopy(existing_schema)
+            schema_dict.setdefault("additionalProperties", True)
+            if "properties" not in schema_dict:
+                schema_dict["properties"] = {}
+            schema_dict["properties"][CONTIG_METADATA_KEY] = {
+                "type": "object",
+                "additionalProperties": True,
+            }
+            tables.metadata_schema = tskit.MetadataSchema(schema_dict)
+        
+        tables.metadata = meta
+        
+        ts_final = tables.tree_sequence()
+        ta_dict[key] = ts_final
+
+    return TreesAssemblage(ta_dict)
 
 
 def _get_shared_for_contig(ts, is_shared_global, contig_index):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public function to build multi-contig assemblages from multiple tree sequences, with configurable contig identifiers, symbols, types, and optional shared-node marking; includes a quick-start usage example.

* **Tests**
  * Added comprehensive tests validating contig construction, metadata handling, shared-node behavior, default/index assignment, and input validation/error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->