### PR TITLE
Add cross-contig PCA support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Python library for efficiently storing and analyzing multiple chromosomes (con
 Population genetics simulators like **msprime** and **SLiM** (prior to v5) typically produce separate tree sequences for each chromosome. `tskit_multichrom` provides:
 
 - **Unified storage**: Manage multiple per-chromosome tree sequences as a single `TreesAssemblage` object
-- **Cross-chromosome analysis**: Compute statistics across all chromosomes when samples are shared (e.g., diversity)
+- **Cross-chromosome analysis**: Compute statistics across all chromosomes when samples are shared (e.g., diversity, PCA)
 - **Efficient subsetting**: Create subsets (e.g., autosomes only) without copying underlying tree sequences
 - **Format conversion**: Convert between multi-contig archives and single merged tree sequences
 - **SLiM compatibility**: Seamless conversion to/from SLiM's tree sequence archives
@@ -94,8 +94,9 @@ diversity = ta.stats.diversity()
 # With specific samples
 diversity = ta.stats.diversity(sample_sets=[[0, 1, 2], [3, 4, 5]])
 
-# By individual across all contigs
-diversity = ta.stats.diversity(individuals=[0, 1])
+# Some stats can be run by individual (e.g. PCA)
+# These do not require phasing across chromosomes
+pca_result = ta.stats.pca(num_components=2, individuals=[0, 1, 2, 3])
 ```
 
 ### Format Conversion

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -134,3 +134,80 @@ class TestDiversity:
         simplified_value = ta_shared.stats.diversity()
 
         assert simplified_value == pytest.approx(explicit_value)
+
+
+class TestPCA:
+    def test_pca_default_matches_to_ts(self):
+        ta = _make_two_contig_archive_shared_samples_only()
+        samples = np.asarray(sorted(ta.global_phased_node_ids), dtype=np.int32)
+        expected = ta.to_ts().pca(num_components=2, samples=samples, random_seed=42)
+        actual = ta.stats.pca(num_components=2, random_seed=42)
+
+        assert actual.eigenvalues == pytest.approx(expected.eigenvalues)
+        assert np.abs(actual.factors) == pytest.approx(np.abs(expected.factors))
+
+    def test_pca_with_explicit_samples(self):
+        ta = _make_two_contig_archive_shared_samples_only()
+        samples = sorted(ta.global_phased_node_ids)[:2]
+        result = ta.stats.pca(num_components=1, samples=samples, random_seed=1)
+        assert result.factors.shape == (2, 1)
+
+    def test_pca_samples_must_be_globally_phased(self):
+        ta = make_autosomes_plus_x_archive()
+        nonglobal = sorted(
+            set(range(ta.contig("chr1").num_samples)) - ta.global_phased_node_ids
+        )
+        assert len(nonglobal) > 0, "expected nonglobal sample nodes"
+        with pytest.raises(ValueError, match="global_phased_node_ids"):
+            ta.stats.pca(num_components=1, samples=nonglobal, random_seed=1)
+
+    def test_pca_default_raises_for_nonglobal_sample_arg(self):
+        ta = make_autosomes_plus_x_archive()
+        assert ta.is_nonglobal_sample_arg
+        with pytest.raises(ValueError, match="individuals or samples"):
+            ta.stats.pca(num_components=1)
+
+    def test_pca_with_individuals_rejects_mixed_types(self):
+        ta = make_autosomes_plus_x_archive()
+        assert ta.is_nonglobal_sample_arg
+        with pytest.raises(ValueError, match="same type"):
+            ta.stats.pca(num_components=1, individuals=[0, 1])
+
+    def test_pca_with_individuals_matches_to_ts(self):
+        ta = _make_two_contig_archive_shared_samples_only()
+        individuals = [0, 1]
+        expected = ta.to_ts().pca(
+            num_components=1, individuals=individuals, random_seed=42
+        )
+        actual = ta.stats.pca(
+            num_components=1, individuals=individuals, random_seed=42
+        )
+        assert actual.eigenvalues == pytest.approx(expected.eigenvalues)
+        assert np.abs(actual.factors) == pytest.approx(np.abs(expected.factors))
+
+    def test_pca_cannot_specify_samples_and_individuals(self):
+        ta = _make_two_contig_archive_shared_samples_only()
+        with pytest.raises(ValueError, match="Cannot specify both"):
+            ta.stats.pca(num_components=1, samples=[0], individuals=[0])
+
+    def test_pca_with_individuals_fully_nonglobal_sample_arg(self):
+        ta = make_two_contig_archive(mark_shared=False)
+        assert ta.is_nonglobal_sample_arg
+        assert len(ta.global_phased_node_ids) == 0
+
+        with pytest.raises(ValueError, match="individuals or samples"):
+            ta.stats.pca(num_components=1)
+
+        individuals = [0, 1]
+        ts_compact = ta.to_ts()
+        ts_compact = ts_compact.simplify(
+            samples=ts_compact.samples(), record_provenance=False
+        )
+        expected = ts_compact.pca(
+            num_components=1, individuals=individuals, random_seed=7
+        )
+        actual = ta.stats.pca(
+            num_components=1, individuals=individuals, random_seed=7
+        )
+        assert actual.eigenvalues == pytest.approx(expected.eigenvalues)
+        assert np.abs(actual.factors) == pytest.approx(np.abs(expected.factors))

--- a/tskit_multichrom/stats.py
+++ b/tskit_multichrom/stats.py
@@ -97,6 +97,120 @@ class TreesAssemblageStats:
             return float(out)
         return out
 
+    def pca(
+        self,
+        num_components,
+        *,
+        windows=None,
+        samples=None,
+        individuals=None,
+        time_windows=None,
+        mode="branch",
+        centre=True,
+        num_iterations=5,
+        num_oversamples=None,
+        random_seed=None,
+        range_sketch=None,
+    ):
+        """
+        Perform PCA across all contigs.
+
+        Internally calls ``ta.to_ts()`` to obtain a single combined tree
+        sequence and then delegates to :meth:`tskit.TreeSequence.pca`.
+
+        When ``samples`` is provided (or defaulted) every sample node ID must
+        be globally phased, consistent with the requirements of
+        :meth:`diversity`. When ``individuals`` is provided, all contigs must
+        share the same chromosome type so that per-individual ploidy is
+        consistent across contigs.
+
+        Parameters
+        ----------
+        num_components : int
+            Number of principal components to return.
+        windows : list, optional
+            Genomic windows; coordinates refer to the combined tree sequence
+            returned by ``ta.to_ts()``.
+        samples : array_like, optional
+            Sample node IDs. Must be globally phased. Mutually exclusive with
+            ``individuals``.
+        individuals : array_like, optional
+            Individual IDs forwarded to ``ts.pca()``. All contigs must share
+            the same chromosome type. Mutually exclusive with ``samples``.
+        time_windows, mode, centre, num_iterations, num_oversamples,
+        random_seed, range_sketch :
+            Forwarded verbatim to :meth:`tskit.TreeSequence.pca`.
+
+        Returns
+        -------
+        tskit.PCAResult
+
+        Notes
+        -----
+        TODO: A more efficient implementation could combine per-contig PCA
+        results mathematically (via a block-structured GRM), avoiding the cost
+        of materialising ``to_ts()`` for large assemblages.
+        """
+        if samples is not None and individuals is not None:
+            raise ValueError("Cannot specify both samples and individuals")
+
+        ts = self._ta.to_ts()
+
+        if individuals is not None:
+            types = {key.type for key in self._ta.contigs}
+            if len(types) > 1:
+                raise ValueError(
+                    "pca with individuals requires all contigs to be the same"
+                    f" type; found types: {sorted(types)}"
+                )
+            # tskit's pca requires sample node IDs to be contiguous [0, n).
+            # to_ts() may interleave ancestral nodes among non-shared sample
+            # nodes, so simplify first to compact sample IDs.
+            ts = ts.simplify(samples=ts.samples(), record_provenance=False)
+            return ts.pca(
+                num_components=num_components,
+                windows=windows,
+                individuals=individuals,
+                time_windows=time_windows,
+                mode=mode,
+                centre=centre,
+                num_iterations=num_iterations,
+                num_oversamples=num_oversamples,
+                random_seed=random_seed,
+                range_sketch=range_sketch,
+            )
+
+        if samples is None:
+            if self._ta.is_nonglobal_sample_arg:
+                raise ValueError(
+                    "individuals or samples must be provided when nonglobal"
+                    " sample nodes are present"
+                )
+            effective_samples = np.asarray(
+                sorted(self._ta.global_phased_node_ids), dtype=np.int32
+            )
+        else:
+            global_phased = set(self._ta.global_phased_node_ids)
+            for sid in samples:
+                if int(sid) not in global_phased:
+                    raise ValueError(
+                        f"Sample node {sid} is not in global_phased_node_ids"
+                    )
+            effective_samples = samples
+
+        return ts.pca(
+            num_components=num_components,
+            windows=windows,
+            samples=effective_samples,
+            time_windows=time_windows,
+            mode=mode,
+            centre=centre,
+            num_iterations=num_iterations,
+            num_oversamples=num_oversamples,
+            random_seed=random_seed,
+            range_sketch=range_sketch,
+        )
+
 
 def _iter_sample_ids(sample_sets):
     """Yield sample IDs from list[int] or list[list[int]] sample_sets values."""


### PR DESCRIPTION
I'm not sure this is 100% correct. It needs some careful manual testing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added cross-chromosome Principal Component Analysis (PCA) supporting global phased samples and individual-based analysis configurations without requiring cross-chromosome phasing.

* **Documentation**
  * Updated README with expanded cross-chromosome analysis feature description and PCA usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->